### PR TITLE
Support AndroidX

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,7 +24,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
AndroidX 를 지원하기 위해서는 compile SDK 를 Android 9.0 ( API level 28 ) 이상으로 설정해야 합니다.

https://developer.android.com/jetpack/androidx/#using_androidx
